### PR TITLE
Improved express() function in vector module

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3661,6 +3661,9 @@ def test_sympy__vector__coordsysrect__CoordSysCartesian():
     from sympy.vector.coordsysrect import CoordSysCartesian
     assert _test_args(CoordSysCartesian('C'))
 
+def test_sympy__vector__coordsyssph__CoordSysSpherical():
+    from sympy.vector.coordsyssph import CoordSysSpherical
+    assert _test_args(CoordSysSpherical('C'))
 
 def test_sympy__vector__point__Point():
     from sympy.vector.point import Point

--- a/sympy/vector/coordsyssph.py
+++ b/sympy/vector/coordsyssph.py
@@ -5,7 +5,6 @@ from sympy.core.compatibility import string_types, range
 from sympy.core.cache import cacheit
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-from sympy.vector.coordsysrect import CoordSysCartesian
 import sympy.vector
 
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -92,7 +92,6 @@ def express(expr, system, system2=None, variables=False):
             else:
                 if isinstance(system, CoordSysCartesian):
                     if isinstance(system2, CoordSysSpherical):
-                        print(parts[i].components[system.j])
                         x = parts[i].components[system.i]
                         y = parts[i].components[system.j]
                         z = parts[i].components[system.k]


### PR DESCRIPTION
improved express to return vectors from cartesian to spherical and frm spherical to cartesian.
#### Example:

> > > from sympy.vector import CoordSysCartesian
> > > from sympy.vector import CoordSysSpherical
> > > from sympy.vector.functions import express
> > > A = CoordSysCartesian('A')
> > > x = 3_A.i + 4_A.j + 5_A.k
> > > B = CoordSysSpherical('B')
> > > y = 3_B.rˆ + 4_B.θˆ + 5_B.φˆ
> > > print(express(x,A,B))
> > > (5_sqrt(2))_B.rˆ + (atan(4/3))_B.θˆ + pi/4_B.φˆ
> > > print(express(y,B,A))
> > > (3_sin(4)_cos(5))_B.i + (3_sin(4)_sin(5))_B.j + (3_cos(4))_B.k
